### PR TITLE
build: don't hardcode path to bash

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/coreos-userdata-validator"


### PR DESCRIPTION
Not all distros use /usr/bin/bash. Instead, ask the environment for
Bash.