### PR TITLE
main: handle unknown version case

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/coreos/coreos-cloudinit/config/validate"
 	ignConfig "github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/validate/report"
 	"github.com/crawford/nap"
 	"github.com/gorilla/mux"
 )
@@ -102,6 +103,13 @@ func putValidate(r *http.Request) (interface{}, nap.Status) {
 			return nil, nap.InternalError{err.Error()}
 		}
 		return rpt.Entries(), nap.OK{}
+	case ignConfig.ErrUnknownVersion:
+		return report.Report{
+			Entries: []report.Entry{{
+				Kind:    report.EntryError,
+				Message: "Failed to parse config. Is this a valid Ignition Config, Cloud-Config, or script?",
+			}},
+		}, nap.OK{}
 	default:
 		rpt.Sort()
 		return rpt.Entries, nap.OK{}

--- a/validate.go
+++ b/validate.go
@@ -94,17 +94,17 @@ func putValidate(r *http.Request) (interface{}, nap.Status) {
 
 	config := bytes.Replace(body, []byte("\r"), []byte{}, -1)
 
-	_, report, err := ignConfig.Parse(config)
+	_, rpt, err := ignConfig.Parse(config)
 	switch err {
 	case ignConfig.ErrCloudConfig, ignConfig.ErrEmpty, ignConfig.ErrScript:
-		report, err := validate.Validate(config)
+		rpt, err := validate.Validate(config)
 		if err != nil {
 			return nil, nap.InternalError{err.Error()}
 		}
-		return report.Entries(), nap.OK{}
+		return rpt.Entries(), nap.OK{}
 	default:
-		report.Sort()
-		return report.Entries, nap.OK{}
+		rpt.Sort()
+		return rpt.Entries, nap.OK{}
 	}
 }
 


### PR DESCRIPTION
If Ignition was unable to parse the config as an Ignition Config, Cloud
Config, or script, it will return ErrUnknownVersion. This was ignored
before which resulted in the validator claiming that the config was
valid. This catches that case and returns an error.

Fixes https://github.com/coreos/bugs/issues/2062.